### PR TITLE
Add /say endpoint with validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,8 @@
     "": {
       "name": "hono-sample",
       "dependencies": {
-        "hono": "^4.6.9"
+        "hono": "^4.6.9",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241022.0",
@@ -1472,7 +1473,6 @@
       "version": "3.23.8",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "deploy": "wrangler deploy --minify"
   },
   "dependencies": {
-    "hono": "^4.6.9"
+    "hono": "^4.6.9",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241022.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,27 @@
 import { Hono } from 'hono'
+import { z } from 'zod'
 
 const app = new Hono()
 
 app.get('/', (c) => {
   return c.text('Hello Hono!')
+})
+
+app.post('/say', async (c) => {
+  const body = await c.req.json()
+  const schema = z.object({
+    message: z.string(),
+    name: z.string()
+  })
+
+  const result = schema.safeParse(body)
+
+  if (!result.success) {
+    return c.json({ error: 'Invalid request body' }, 400)
+  }
+
+  const { message, name } = result.data
+  return c.json({ message, name })
 })
 
 export default app


### PR DESCRIPTION
Implement a POST endpoint for `/say` to echo back the message and name sent in the request.

* **Endpoint Addition**
  - Add a POST endpoint for `/say` in `src/index.ts`.

* **Request Handling**
  - Extract the message and name from the request body using `c.req.json()`.
  - Validate the request body to ensure it contains `message` and `name` fields using `zod`.

* **Response**
  - Return the extracted message and name in the response using `c.json`.

* **Dependencies**
  - Add `zod` as a dependency in `package.json` and `package-lock.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/YuheiFUJITA/hono-sample/pull/1?shareId=b2b438f3-b446-48c3-b783-7353c065f3e8).